### PR TITLE
feat(api): Implement PATCH for partial updates and enhance content ne…

### DIFF
--- a/LeasingSys_API/Controllers/LeasingAPIController.cs
+++ b/LeasingSys_API/Controllers/LeasingAPIController.cs
@@ -1,6 +1,7 @@
 using LeasingSys_API.Data;
 using LeasingSys_API.Models;
 using LeasingSys_API.Models.DTO;
+using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LeasingSys_API.Controllers;
@@ -8,17 +9,157 @@ namespace LeasingSys_API.Controllers;
 // [Route("api/[controller]")]
 [Route("api/leasingAPI")]
 [ApiController]
-public class LeasingAPIController : ControllerBase // 继承 Controller 则会额外支持 MVC 特性.
+public class LeasingAPIController : ControllerBase // 继承 Controller 则会额外支持 MVC 特性
 {
     [HttpGet]
-    public IEnumerable<LeasingDTO> GetLeasing()
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<IEnumerable<LeasingDTO>> GetLeasing()
     {
-        return LeasingOffice.LeasingList;
+        // ActionResult 类型可以灵活控制 Ok(data)、NotFound()、BadRequest()、CreatedAtRoute().
+        return Ok(LeasingOffice.LeasingList);
     }
 
-    [HttpGet("id:int")]
-    public LeasingDTO GetLeasing(int id)
+    [HttpGet("{id:int}", Name = "GetLeasing")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LeasingDTO))] // 可通过 ActionResult<T> 隐式推断
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)] // 避免 SwaggerUI 未记录此状态码
+    public ActionResult<LeasingDTO> GetLeasing(int id)
     {
-        return LeasingOffice.LeasingList.FirstOrDefault(u => u.Id == id);
+        if (id <= 0)
+        {
+            return BadRequest();
+        }
+
+        var leasingDto = LeasingOffice.LeasingList.FirstOrDefault(u => u.Id == id);
+        if (leasingDto == null)
+        {
+            return NotFound();
+        }
+        else
+        {
+            return Ok(leasingDto);
+        }
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public ActionResult<LeasingDTO> CreateLeasing([FromBody] LeasingDTO leasingDto) // [FromBody] -> 数据来自请求体
+    {
+        // 如果请求的 Body 有问题，导致 leasingDto 可能会变成 null，
+        // 那么请求根本就不会进入到您的 Action 方法内部，而是提前就被框架拦截并返回 400 错误.
+        // 因此不需要判断 if (leasingDto is null) {}
+        // 甚至因为框架帮我们处理了空请求体后, 这个方法内部都不会运行.
+        // if (!ModelState.IsValid)
+        // {
+        //     return Ok(leasingDto);
+        // }
+        if (LeasingOffice.LeasingList.FirstOrDefault(u => u.Name.ToLower() == leasingDto.Name.ToLower()) != null)
+        {
+            // 报错的时候会显示:
+            // {
+            //     "Key -> NameIsUnique": ["ErrorMessage -> Name already exists"]
+            // }
+            ModelState.AddModelError("Key -> NameIsUnique", "ErrorMessage -> Name already exists");
+            return BadRequest(ModelState);
+        }
+
+        if (leasingDto.Id < 0)
+        {
+            return BadRequest();
+        }
+
+        if (leasingDto.Id > 0)
+        {
+            return StatusCode(StatusCodes.Status400BadRequest, leasingDto);
+        }
+
+        leasingDto.Id = LeasingOffice.LeasingList.OrderByDescending(u => u.Id).FirstOrDefault()?.Id + 1 ?? 0;
+        LeasingOffice.LeasingList.Add(leasingDto);
+        // return Ok(leasingDto);
+
+        // CreatedAtRoute 会设置 201 状态码 
+        return CreatedAtRoute("GetLeasing", new { id = leasingDto.Id }, leasingDto);
+    }
+
+    // Name = "DeleteLeasing" 使得 CreatedAtRoute 或 RedirectToRoute 方法安全地生成 URL.
+    [HttpDelete("{id:int}", Name = "DeleteLeasing")]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public IActionResult DeleteLeasing(int id)
+    {
+        if (id <= 0)
+        {
+            return BadRequest();
+        }
+
+        var leasingDto = LeasingOffice.LeasingList.FirstOrDefault(u => u.Id == id);
+        if (leasingDto == null)
+        {
+            return NotFound();
+        }
+
+        LeasingOffice.LeasingList.Remove(leasingDto);
+        return NoContent();
+    }
+
+    // [HttpPut("{id:int}", Name = "UpdateLeasing")]
+    // [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    // [ProducesResponseType(StatusCodes.Status204NoContent)]
+    // public IActionResult UpdateLeasing(
+    //     [FromRoute(Name = "id")] int productId,
+    //     [FromBody] LeasingDTO leasingDto) // 参数名和占位符名不一致, 需要 [FromRoute(Name = ...
+    // {
+    //     if (productId <= 0 || productId != leasingDto.Id)
+    //     {
+    //         return BadRequest();
+    //     }
+    //
+    //     var leasingToUpdate = LeasingOffice.LeasingList.FirstOrDefault(u => u.Id == productId);
+    //     // 全部替换一次会很消耗计算资源. 应该使用 JSON patch.
+    //     leasingToUpdate.Name = leasingDto.Name;
+    //     leasingToUpdate.Occupancy = 0;
+    //     leasingToUpdate.Square = 0;
+    //
+    //     return NoContent();
+    // }
+
+    [HttpPatch("{id:int}", Name = "UpdatePartialLeasing")]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public IActionResult UpdateLeasing(
+        [FromRoute(Name = "id")] int productId,
+        [FromBody] JsonPatchDocument<LeasingDTO>? patchLeasingDto)
+    {
+        if (productId <= 0 || patchLeasingDto is null)
+        {
+            return BadRequest();
+        }
+
+        var leasingToUpdate = LeasingOffice.LeasingList.FirstOrDefault(u => u.Id == productId);
+        if (leasingToUpdate is null)
+        {
+            return NotFound();
+        }
+
+        // [
+        //     {
+        //         "op": "replace",
+        //         "path": "/YourPropertyName",
+        //         "value": "Your New Value"
+        //     }
+        // ]
+        patchLeasingDto.ApplyTo(leasingToUpdate, ModelState);
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        return NoContent();
     }
 }

--- a/LeasingSys_API/Data/LeasingOffice.cs
+++ b/LeasingSys_API/Data/LeasingOffice.cs
@@ -6,8 +6,8 @@ public static class LeasingOffice
 {
     public static List<LeasingDTO> LeasingList = new List<LeasingDTO>
     {
-        new LeasingDTO { Id = 1, Name = "Leasing1" },
-        new LeasingDTO { Id = 2, Name = "Leasing2" },
-        new LeasingDTO { Id = 3, Name = "Leasing3" }
+        new LeasingDTO { Id = 1, Name = "Leasing1", Occupancy = 4, Square = 100 },
+        new LeasingDTO { Id = 2, Name = "Leasing2", Occupancy = 4, Square = 100 },
+        new LeasingDTO { Id = 3, Name = "Leasing3", Occupancy = 4, Square = 100 },
     };
 }

--- a/LeasingSys_API/LeasingSys_API.csproj
+++ b/LeasingSys_API/LeasingSys_API.csproj
@@ -7,6 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
     </ItemGroup>

--- a/LeasingSys_API/Models/DTO/LeasingDto.cs
+++ b/LeasingSys_API/Models/DTO/LeasingDto.cs
@@ -1,7 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace LeasingSys_API.Models.DTO;
 
 public class LeasingDTO
 {
     public int Id { get; set; }
     public string Name { get; set; }
+    public int Occupancy { get; set; }
+    public int Square { get; set; }
 }

--- a/LeasingSys_API/Program.cs
+++ b/LeasingSys_API/Program.cs
@@ -8,9 +8,12 @@ public class Program
 
         // Add services to the container.
 
-        builder.Services.AddControllers();
+        // 如果客户端通过 Accept 请求头请求一个我们的 API 无法生成的数据格式，
+        // 那么服务器将严格地返回一个 406 Not Acceptable 错误，而不是“自作主张”地返回一个默认格式（如 JSON）的数据.
+        builder.Services.AddControllers(option => { option.ReturnHttpNotAcceptable = true; }
+        ).AddNewtonsoftJson().AddXmlDataContractSerializerFormatters();
         // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-        
+
         builder.Services.AddSwaggerGen();
 
         var app = builder.Build();


### PR DESCRIPTION
…gotiation

This commit significantly refactors and enhances the LeasingAPIController and its underlying service configuration to align with RESTful best practices and provide a more robust and flexible API.

The key improvements are categorized into two main areas: implementing a proper partial update mechanism using HTTP PATCH and expanding the API's content negotiation capabilities.

### 1. PATCH Endpoint for Partial Updates

The previous PUT method for updates, which required the full resource representation, has been replaced with a more semantically correct HTTP PATCH endpoint.

- RESTful Semantics: Changed the endpoint attribute from `[HttpPut]` to `[HttpPatch]` to correctly represent partial updates of a resource, where the client only sends the fields they wish to change.

- `JsonPatchDocument<T>` Implementation: The endpoint now accepts a `JsonPatchDocument<LeasingDTO>`, which is the standard ASP.NET Core implementation for the JSON Patch standard (RFC 6902). This allows for a series of atomic operations (`replace`, `add`, `remove`, etc.) to be sent in a single request.

- Safe Application of Patches: The core update logic is now handled by `patchLeasingDto.ApplyTo(leasingToUpdate, ModelState)`. This method safely applies the operations to the in-memory object. Crucially, it integrates with `ModelState`, so any errors during the patch application (e.g., invalid path, type conversion failure) are added to `ModelState` instead of throwing an exception.

- Validation Flow: The `ModelState.IsValid` check is now correctly placed *after* the `ApplyTo` call to catch these patch-related errors and return a `400 Bad Request` with detailed information.

- Route Template Fix: Corrected a minor bug in the `GetLeasing(id)` endpoint's route template from `"id:int"` to `"{id:int}"` to ensure proper parameter binding from the URL path.

### 2. Enhanced Content Negotiation and Formatters

The API's service configuration in `Program.cs` has been updated to provide a more flexible and strict content negotiation experience.

- Strict Content Negotiation: `ReturnHttpNotAcceptable = true` has been enabled. If a client sends an `Accept` header requesting a media type that the API cannot produce (e.g., `application/yaml`), the server will now correctly return a `406 Not Acceptable` status code instead of ignoring the header and sending the default JSON response.

- XML Support: Added support for XML content negotiation by registering formatters with `.AddXmlDataContractSerializerFormatters()`. The API can now serve responses in either `application/json` or `application/xml`, depending on the client's `Accept` header.

- Newtonsoft.Json Integration: The API is configured to use `Newtonsoft.Json` for JSON serialization, providing more flexibility and control over the serialization process compared to the default `System.Text.Json`.